### PR TITLE
Fix: compatibility issue to the latest version of woocommerce

### DIFF
--- a/woo-chapa.php
+++ b/woo-chapa.php
@@ -34,7 +34,17 @@ function waf_wc_chapa_init() {
     add_filter( 'woocommerce_available_payment_gateways', 'conditionally_hide_waf_chapa_payment_gateways' );
 
 }
+add_action( 'before_woocommerce_init', 'waf_wc_chapa_before_init');
 add_action( 'plugins_loaded', 'waf_wc_chapa_init' );
+
+/**
+ * before woocommerce init
+ */
+function waf_wc_chapa_before_init() {
+	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+	}
+}
 
 
 /**


### PR DESCRIPTION
I encountered an issue with the Chapa Payment Gateway plugin showing the error: "This plugin is incompatible with the enabled WooCommerce feature 'High-Performance order storage', it shouldn't be activated." Additionally, I noticed that the plugin had compatibility issues with the latest WooCommerce versions.

To address this, I referred to the official WooCommerce documentation and implemented the waf_wc_chapa_before_init function to execute before WooCommerce initialization. I also refactored the code accordingly.

The modified code now works seamlessly with the latest version of WooCommerce. After extensive debugging, I have resolved the issue and am excited to contribute this fix to the project.

Please test the updated code and consider integrating it into the main branch.